### PR TITLE
Fix SDK version for bash

### DIFF
--- a/.doc_gen/metadata/vpc_gs_metadata.yaml
+++ b/.doc_gen/metadata/vpc_gs_metadata.yaml
@@ -15,7 +15,7 @@ vpc_GettingStartedCLI:
   languages:
     Bash:
       versions:
-        - sdk_version: 3
+        - sdk_version: 2
           github_name: "Sample developer tutorials"
           github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/002-vpc-gs
           excerpts:
@@ -44,7 +44,7 @@ vpc_GettingStartedIpam:
   languages:
     Bash:
       versions:
-        - sdk_version: 3
+        - sdk_version: 2
           github_name: "Sample developer tutorials"
           github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/009-vpc-ipam-gs
           excerpts:
@@ -67,7 +67,7 @@ vpc_GettingStartedPrivate:
   languages:
     Bash:
       versions:
-        - sdk_version: 3
+        - sdk_version: 2
           github_name: "Sample developer tutorials"
           github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/008-vpc-private-servers-gs
           excerpts:


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Based on code review feedback, the major version for the SDK for Bash should be 2 and not 3. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
