### PR TITLE
Metadata for tutorials with pending service registrations

### DIFF
--- a/.doc_gen/config/services.yaml
+++ b/.doc_gen/config/services.yaml
@@ -1,0 +1,50 @@
+account:
+  long: "&AWS; Account Management"
+  short: Account
+  sort: Account Management
+  version: "2021-02-01"
+chime-sdk-voice:
+  long: "Amazon Chime SDK Voice"
+  short: Chime SDK Voice
+  sort: Chime SDK Voice
+  version: "2022-08-03"
+datazone:
+  long: "Amazon DataZone"
+  short: DataZone
+  sort: DataZone
+  version: "2018-05-10"
+dms:
+  long: "&AWS; Database Migration Service"
+  short: DMS
+  sort: Database Migration Service
+  version: "2016-01-01"
+kinesisvideo:
+  long: "Amazon Kinesis Video Streams"
+  short: Kinesis Video
+  sort: Kinesis Video Streams
+  version: "2017-09-30"
+mq:
+  long: "Amazon MQ"
+  short: Amazon MQ
+  sort: MQ
+  version: "2017-11-27"
+network-firewall:
+  long: "&AWS; Network Firewall"
+  short: Network Firewall
+  sort: Network Firewall
+  version: "2020-11-12"
+pinpoint-sms-voice-v2:
+  long: "&AWS; End User Messaging"
+  short: End User Messaging
+  sort: End User Messaging
+  version: "2022-03-31"
+qbusiness:
+  long: "Amazon Q Business"
+  short: Q Business
+  sort: Q Business
+  version: "2023-11-27"
+sso-admin:
+  long: "&AWS; IAM Identity Center"
+  short: IAM Identity Center
+  sort: IAM Identity Center
+  version: "2020-07-20"

--- a/.doc_gen/metadata/account_aws_account_metadata.yaml
+++ b/.doc_gen/metadata/account_aws_account_metadata.yaml
@@ -1,0 +1,20 @@
+account_GettingStarted_077:
+  title: Managing your account
+  title_abbrev: Managing your account
+  synopsis_list:
+    - Update account name
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/077-aws-account-management-gs
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/077-aws-account-management-gs/aws-account-management-gs.sh
+  services:
+    account: {GetAlternateContact, GetContactInformation, GetRegionOptStatus, ListRegions}
+    s3: {ListBuckets}
+    sts: {GetCallerIdentity}

--- a/.doc_gen/metadata/chime_sdk_voice_chimesdk_routingcalls_metadata.yaml
+++ b/.doc_gen/metadata/chime_sdk_voice_chimesdk_routingcalls_metadata.yaml
@@ -1,0 +1,26 @@
+chime_sdk_voice_GettingStarted_007:
+  title: Routing calls to Lambda functions for Amazon Chime SDK PSTN audio
+  title_abbrev: Routing calls to Lambda functions for Amazon Chime SDK PSTN audio
+  synopsis_list:
+    - Create a Lambda function for call handling
+    - Create a SIP media application
+    - Set up call routing with SIP rules
+    - Set up redundancy with multiple SIP media applications
+    - Create outbound calls
+    - Clean up resources
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/007-chimesdk-routingcalls
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/007-chimesdk-routingcalls/chimesdk-routingcalls.sh
+  services:
+    chime-sdk-voice: {CreatePhoneNumberOrder, CreateSipMediaApplication, CreateSipMediaApplicationCall, CreateSipRule, DeleteSipMediaApplication, DeleteSipRule, ListPhoneNumbers, ListSipMediaApplications, ListSipRules, SearchAvailablePhoneNumbers, UpdateSipMediaApplicationCall}
+    iam: {AttachRolePolicy, CreateRole, DeleteRole, DetachRolePolicy, GetRole}
+    lambda: {AddPermission, CreateFunction, DeleteFunction, GetFunction}
+    sts: {GetCallerIdentity}

--- a/.doc_gen/metadata/datazone_amazon_datazone_metadata.yaml
+++ b/.doc_gen/metadata/datazone_amazon_datazone_metadata.yaml
@@ -1,0 +1,26 @@
+datazone_GettingStarted_059:
+  title: Getting started with Amazon DataZone
+  title_abbrev: Getting started with Amazon DataZone
+  synopsis_list:
+    - Create an Amazon DataZone domain
+    - Create projects
+    - Create an environment profile and environment
+    - Create a data source for Glue
+    - Create and publish custom assets
+    - Clean up resources
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/059-amazon-datazone-gs
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/059-amazon-datazone-gs/amazon-datazone-gs.sh
+  services:
+    datazone: {AcceptSubscriptionRequest, CreateAsset, CreateAssetType, CreateDataSource, CreateDomain, CreateEnvironment, CreateEnvironmentProfile, CreateFormType, CreateListingChangeSet, CreateProject, CreateSubscriptionRequest, DeleteAsset, DeleteAssetType, DeleteDataSource, DeleteDomain, DeleteEnvironment, DeleteEnvironmentProfile, DeleteFormType, DeleteProject, DeleteSubscriptionRequest, GetAssetType, GetDomain, GetEnvironment, ListEnvironmentBlueprints, SearchListings}
+    glue: {CreateDatabase, GetDatabases}
+    iam: {AttachRolePolicy, CreateRole, GetRole, PutRolePolicy}
+    sts: {GetCallerIdentity}

--- a/.doc_gen/metadata/ec2_aws_database_metadata.yaml
+++ b/.doc_gen/metadata/ec2_aws_database_metadata.yaml
@@ -1,0 +1,28 @@
+ec2_GettingStarted_075:
+  title: Getting started with Database Migration Service
+  title_abbrev: Getting started with Database Migration Service
+  synopsis_list:
+    - Create a VPC for your migration resources
+    - Create database parameter groups
+    - Create source and target databases
+    - Create an EC2 client instance
+    - Create a replication instance
+    - Create source and target endpoints
+    - Create and start a migration task
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/075-aws-database-migration-service-gs
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/075-aws-database-migration-service-gs/aws-database-migration-service-gs.sh
+  services:
+    dms: {CreateEndpoint, CreateReplicationInstance, CreateReplicationSubnetGroup, CreateReplicationTask, DeleteEndpoint, DeleteReplicationInstance, DeleteReplicationSubnetGroup, DeleteReplicationTask, DescribeReplicationInstances, DescribeReplicationTasks, DescribeTableStatistics, StartReplicationTask, TestConnection}
+    ec2: {AssociateRouteTable, AttachInternetGateway, AuthorizeSecurityGroupIngress, CreateInternetGateway, CreateKeyPair, CreateRoute, CreateRouteTable, CreateSubnet, CreateVpc, DeleteInternetGateway, DeleteKeyPair, DeleteRouteTable, DeleteSubnet, DeleteVpc, DescribeAvailabilityZones, DescribeImages, DescribeInstanceTypeOfferings, DescribeInstances, DescribeSecurityGroups, DescribeSubnets, DescribeVpcs, DetachInternetGateway, ModifyVpcAttribute, RunInstances, TerminateInstances, Wait}
+    rds: {CreateDbInstance, CreateDbParameterGroup, CreateDbSubnetGroup, DeleteDbInstance, DeleteDbParameterGroup, DeleteDbSubnetGroup, DescribeDbInstances, ModifyDbParameterGroup, Wait}
+    secrets-manager: {CreateSecret, DeleteSecret, GetSecretValue}
+    sts: {GetCallerIdentity}

--- a/.doc_gen/metadata/ec2_aws_network_metadata.yaml
+++ b/.doc_gen/metadata/ec2_aws_network_metadata.yaml
@@ -1,0 +1,24 @@
+ec2_GettingStarted_047:
+  title: Getting started with Network Firewall
+  title_abbrev: Getting started with Network Firewall
+  synopsis_list:
+    - Create rule groups
+    - Create a firewall policy
+    - Create a firewall
+    - Update route tables
+    - Clean up resources
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/047-aws-network-firewall-gs
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/047-aws-network-firewall-gs/aws-network-firewall-gs.sh
+  services:
+    ec2: {CreateRoute, CreateRouteTable, DeleteRoute, DeleteRouteTable, DescribeInternetGateways, DescribeRouteTables, DescribeSubnets, DescribeVpcs}
+    network-firewall: {CreateFirewall, CreateFirewallPolicy, CreateRuleGroup, DeleteFirewall, DeleteFirewallPolicy, DeleteRuleGroup, DescribeFirewall}
+    sts: {GetCallerIdentity}

--- a/.doc_gen/metadata/iam_qbusiness_anon_metadata.yaml
+++ b/.doc_gen/metadata/iam_qbusiness_anon_metadata.yaml
@@ -1,0 +1,22 @@
+iam_GettingStarted_042:
+  title: Creating an Amazon Q Business application environment for anonymous access
+  title_abbrev: Creating an Amazon Q Business application environment for anonymous access
+  synopsis_list:
+    - Create an IAM role for Amazon Q Business
+    - Create an Amazon Q Business application with anonymous access
+    - Verify the application creation
+    - Clean up resources
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/042-qbusiness-anon
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/042-qbusiness-anon/qbusiness-anon.sh
+  services:
+    iam: {AttachRolePolicy, CreateRole, DeleteRole, DetachRolePolicy}
+    qbusiness: {CreateApplication, DeleteApplication, GetApplication}

--- a/.doc_gen/metadata/iam_qbusiness_ica_metadata.yaml
+++ b/.doc_gen/metadata/iam_qbusiness_ica_metadata.yaml
@@ -1,0 +1,26 @@
+iam_GettingStarted_040:
+  title: Creating an Amazon Q Business application
+  title_abbrev: Creating an Amazon Q Business application
+  synopsis_list:
+    - Set up IAM Identity Center
+    - Create IAM roles and policies
+    - Create a user in IAM Identity Center
+    - Create an Amazon Q Business application
+    - Enable creator mode (LLM direct chat)
+    - Assign the user to the application
+    - Create a user subscription
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/040-qbusiness-ica
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/040-qbusiness-ica/qbusiness-ica.sh
+  services:
+    iam: {AttachRolePolicy, CreatePolicy, CreateRole, DeletePolicy, DeleteRole, DetachRolePolicy, GetRole}
+    qbusiness: {CreateApplication, CreateSubscription, DeleteApplication, GetApplication, ListSubscriptions, UpdateChatControlsConfiguration}
+    sso-admin: {CreateApplicationAssignment, DeleteApplicationAssignment, ListApplications, ListInstances}

--- a/.doc_gen/metadata/kinesisvideo_amazon_kinesis_metadata.yaml
+++ b/.doc_gen/metadata/kinesisvideo_amazon_kinesis_metadata.yaml
@@ -1,0 +1,22 @@
+kinesisvideo_GettingStarted_054:
+  title: Getting started with Amazon Kinesis Video Streams
+  title_abbrev: Getting started with Amazon Kinesis Video Streams
+  synopsis_list:
+    - Create a Kinesis video stream
+    - Verify stream creation
+    - Get data endpoints
+    - Send data to your Kinesis video stream
+    - Clean up resources
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/054-amazon-kinesis-video-streams-gs
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/054-amazon-kinesis-video-streams-gs/amazon-kinesis-video-streams-gs.sh
+  services:
+    kinesisvideo: {CreateStream, DeleteStream, DescribeStream, GetDataEndpoint, ListStreams}

--- a/.doc_gen/metadata/mq_amazon_mq_metadata.yaml
+++ b/.doc_gen/metadata/mq_amazon_mq_metadata.yaml
@@ -1,0 +1,26 @@
+mq_GettingStarted_043:
+  title: Getting started with Amazon MQ for ActiveMQ and Secrets Manager
+  title_abbrev: Getting started with Amazon MQ for ActiveMQ and Secrets Manager
+  synopsis_list:
+    - Store broker credentials in Secrets Manager
+    - Create an Amazon MQ broker
+    - Wait for the broker to be in RUNNING state
+    - Get broker connection details
+    - Configure security group for the broker
+    - Create a Java application to connect to the broker
+    - Build and run the application
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/043-amazon-mq-gs
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/043-amazon-mq-gs/amazon-mq-gs.sh
+  services:
+    ec2: {AuthorizeSecurityGroupIngress}
+    mq: {CreateBroker, DeleteBroker, DescribeBroker}
+    secrets-manager: {CreateSecret, DeleteSecret}

--- a/.doc_gen/metadata/sso_admin_aws_iam_metadata.yaml
+++ b/.doc_gen/metadata/sso_admin_aws_iam_metadata.yaml
@@ -1,0 +1,24 @@
+sso_admin_GettingStarted_045:
+  title: Getting started with IAM Identity Center
+  title_abbrev: Getting started with IAM Identity Center
+  synopsis_list:
+    - Enable IAM Identity Center
+    - Create users and groups
+    - Set up user access to accounts (organization instance only)
+    - Set up user access to applications
+    - Clean up resources
+  category: Scenarios
+  languages:
+    Bash:
+      versions:
+        - sdk_version: 2
+          github_name: "Sample developer tutorials"
+          github: https://github.com/aws-samples/sample-developer-tutorials/tree/main/tuts/045-aws-iam-identity-center-gs
+          excerpts:
+            - description:
+              snippet_files:
+                - tuts/045-aws-iam-identity-center-gs/aws-iam-identity-center-gs.sh
+  services:
+    organizations: {DescribeOrganization}
+    sso-admin: {AttachManagedPolicyToPermissionSet, CreateAccountAssignment, CreateApplication, CreateApplicationAssignment, CreateInstance, CreatePermissionSet, DeleteAccountAssignment, DeleteApplication, DeleteApplicationAssignment, DeletePermissionSet, DescribeAccountAssignmentCreationStatus, DescribeAccountAssignmentDeletionStatus, DescribePermissionSetProvisioningStatus, DetachManagedPolicyFromPermissionSet, ListInstances, ProvisionPermissionSet}
+    sts: {GetCallerIdentity}


### PR DESCRIPTION
## Blocked on upstream services.yaml

These 10 metadata files reference services not yet registered in [aws-doc-sdk-examples-tools/services.yaml](https://github.com/awsdocs/aws-doc-sdk-examples-tools/blob/main/aws_doc_sdk_examples_tools/config/services.yaml).

| Service | Tutorials | Status |
|---------|-----------|--------|
| `account` | 077-aws-account-management | Not in services.yaml |
| `chime-sdk-voice` | 007-chimesdk-routingcalls | Not in services.yaml |
| `datazone` | 059-amazon-datazone | Not in services.yaml |
| `dms` | 075-aws-database-migration | Not in services.yaml |
| `kinesisvideo` | 054-amazon-kinesis-video | Not in services.yaml |
| `mq` | 043-amazon-mq | Not in services.yaml |
| `network-firewall` | 047-aws-network-firewall | Not in services.yaml |
| `qbusiness` | 040-qbusiness-ica, 042-qbusiness-anon | Not in services.yaml |
| `sso-admin` | 045-aws-iam-identity-center, 040-qbusiness-ica | Not in services.yaml |

### Next steps

1. Submit a PR to [aws-doc-sdk-examples-tools](https://github.com/awsdocs/aws-doc-sdk-examples-tools) to add these services, or log a SIM ticket (CTI: AWS | Documentation Builds | Content Automation)
2. Once services are added upstream, merge this PR
3. A local `.doc_gen/config/services.yaml` is included for preview builds in the meantime