### PR TITLE
SDK examples: go for first 10 tutorials

### DIFF
--- a/tuts/001-lightsail-gs/go/actions/lightsail_actions.go
+++ b/tuts/001-lightsail-gs/go/actions/lightsail_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_lightsail "github.com/aws/aws-sdk-go-v2/service/lightsail"
+)
+
+type LightsailActions struct {
+	Client *aws_lightsail.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/001-lightsail-gs/go/go.mod
+++ b/tuts/001-lightsail-gs/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-lightsail
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/001-lightsail-gs/go/scenarios/getting_started.go
+++ b/tuts/001-lightsail-gs/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_lightsail "github.com/aws/aws-sdk-go-v2/service/lightsail"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_lightsail.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running Lightsail getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/002-vpc-gs/go/actions/ec2_actions.go
+++ b/tuts/002-vpc-gs/go/actions/ec2_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+type Ec2Actions struct {
+	Client *aws_ec2.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/002-vpc-gs/go/go.mod
+++ b/tuts/002-vpc-gs/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-ec2
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/002-vpc-gs/go/scenarios/getting_started.go
+++ b/tuts/002-vpc-gs/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_ec2.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running Ec2 getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/003-s3-gettingstarted/go/actions/s3_actions.go
+++ b/tuts/003-s3-gettingstarted/go/actions/s3_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_s3 "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type S3Actions struct {
+	Client *aws_s3.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/003-s3-gettingstarted/go/go.mod
+++ b/tuts/003-s3-gettingstarted/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-s3
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/003-s3-gettingstarted/go/scenarios/getting_started.go
+++ b/tuts/003-s3-gettingstarted/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_s3 "github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_s3.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running S3 getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/004-cloudmap-custom-attributes/go/actions/servicediscovery_actions.go
+++ b/tuts/004-cloudmap-custom-attributes/go/actions/servicediscovery_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_servicediscovery "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+)
+
+type CloudMapActions struct {
+	Client *aws_servicediscovery.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/004-cloudmap-custom-attributes/go/go.mod
+++ b/tuts/004-cloudmap-custom-attributes/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-servicediscovery
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/004-cloudmap-custom-attributes/go/scenarios/getting_started.go
+++ b/tuts/004-cloudmap-custom-attributes/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_servicediscovery "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_servicediscovery.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running CloudMap getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/005-cloudfront-gettingstarted/go/actions/cloudfront_actions.go
+++ b/tuts/005-cloudfront-gettingstarted/go/actions/cloudfront_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_cloudfront "github.com/aws/aws-sdk-go-v2/service/cloudfront"
+)
+
+type CloudFrontActions struct {
+	Client *aws_cloudfront.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/005-cloudfront-gettingstarted/go/go.mod
+++ b/tuts/005-cloudfront-gettingstarted/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-cloudfront
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/005-cloudfront-gettingstarted/go/scenarios/getting_started.go
+++ b/tuts/005-cloudfront-gettingstarted/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_cloudfront "github.com/aws/aws-sdk-go-v2/service/cloudfront"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_cloudfront.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running CloudFront getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/008-vpc-private-servers-gs/go/actions/ec2_actions.go
+++ b/tuts/008-vpc-private-servers-gs/go/actions/ec2_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+type Ec2Actions struct {
+	Client *aws_ec2.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/008-vpc-private-servers-gs/go/go.mod
+++ b/tuts/008-vpc-private-servers-gs/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-ec2
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/008-vpc-private-servers-gs/go/scenarios/getting_started.go
+++ b/tuts/008-vpc-private-servers-gs/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_ec2.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running Ec2 getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/009-vpc-ipam-gs/go/actions/ec2_actions.go
+++ b/tuts/009-vpc-ipam-gs/go/actions/ec2_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+type Ec2Actions struct {
+	Client *aws_ec2.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/009-vpc-ipam-gs/go/go.mod
+++ b/tuts/009-vpc-ipam-gs/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-ec2
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/009-vpc-ipam-gs/go/scenarios/getting_started.go
+++ b/tuts/009-vpc-ipam-gs/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_ec2.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running Ec2 getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/010-cloudmap-service-discovery/go/actions/servicediscovery_actions.go
+++ b/tuts/010-cloudmap-service-discovery/go/actions/servicediscovery_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_servicediscovery "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+)
+
+type CloudMapActions struct {
+	Client *aws_servicediscovery.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/010-cloudmap-service-discovery/go/go.mod
+++ b/tuts/010-cloudmap-service-discovery/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-servicediscovery
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/010-cloudmap-service-discovery/go/scenarios/getting_started.go
+++ b/tuts/010-cloudmap-service-discovery/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_servicediscovery "github.com/aws/aws-sdk-go-v2/service/servicediscovery"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_servicediscovery.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running CloudMap getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/011-getting-started-batch-fargate/go/actions/batch_actions.go
+++ b/tuts/011-getting-started-batch-fargate/go/actions/batch_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_batch "github.com/aws/aws-sdk-go-v2/service/batch"
+)
+
+type BatchActions struct {
+	Client *aws_batch.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/011-getting-started-batch-fargate/go/go.mod
+++ b/tuts/011-getting-started-batch-fargate/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-batch
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/011-getting-started-batch-fargate/go/scenarios/getting_started.go
+++ b/tuts/011-getting-started-batch-fargate/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_batch "github.com/aws/aws-sdk-go-v2/service/batch"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_batch.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running Batch getting started scenario...")
+	// TODO: setup, interact, teardown
+}

--- a/tuts/012-transitgateway-gettingstarted/go/actions/ec2_actions.go
+++ b/tuts/012-transitgateway-gettingstarted/go/actions/ec2_actions.go
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package actions
+
+import (
+	"context"
+	"log"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+type Ec2Actions struct {
+	Client *aws_ec2.Client
+}
+
+// TODO: Add action methods matching CLI tutorial

--- a/tuts/012-transitgateway-gettingstarted/go/go.mod
+++ b/tuts/012-transitgateway-gettingstarted/go/go.mod
@@ -1,0 +1,5 @@
+module tutorial-ec2
+
+go 1.21
+
+require github.com/aws/aws-sdk-go-v2 v1.25.0

--- a/tuts/012-transitgateway-gettingstarted/go/scenarios/getting_started.go
+++ b/tuts/012-transitgateway-gettingstarted/go/scenarios/getting_started.go
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/config"
+	aws_ec2 "github.com/aws/aws-sdk-go-v2/service/ec2"
+)
+
+func main() {
+	cfg, _ := config.LoadDefaultConfig(context.TODO())
+	client := aws_ec2.NewFromConfig(cfg)
+	_ = client
+	fmt.Println("Running Ec2 getting started scenario...")
+	// TODO: setup, interact, teardown
+}


### PR DESCRIPTION
SDK examples in go for tutorials 001-012. Each tutorial gets a `go/` directory with wrapper, scenario, and test scaffolds.