### PR TITLE
SDK examples: dotnet for first 10 tutorials

### DIFF
--- a/tuts/001-lightsail-gs/dotnet/001-lightsail-gs.csproj
+++ b/tuts/001-lightsail-gs/dotnet/001-lightsail-gs.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.Lightsail" Version="3.*" /></ItemGroup></Project>

--- a/tuts/001-lightsail-gs/dotnet/GettingStartedScenario.cs
+++ b/tuts/001-lightsail-gs/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lightsail;
+
+var client = new AmazonLightsailClient();
+Console.WriteLine("Running Lightsail getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/001-lightsail-gs/dotnet/LightsailWrapper.cs
+++ b/tuts/001-lightsail-gs/dotnet/LightsailWrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Lightsail;
+using Microsoft.Extensions.Logging;
+
+public class LightsailWrapper
+{
+    private readonly IAmazonLightsail _client;
+    private readonly ILogger<LightsailWrapper> _logger;
+
+    public LightsailWrapper(IAmazonLightsail client, ILogger<LightsailWrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/002-vpc-gs/dotnet/002-vpc-gs.csproj
+++ b/tuts/002-vpc-gs/dotnet/002-vpc-gs.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.Ec2" Version="3.*" /></ItemGroup></Project>

--- a/tuts/002-vpc-gs/dotnet/Ec2Wrapper.cs
+++ b/tuts/002-vpc-gs/dotnet/Ec2Wrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+using Microsoft.Extensions.Logging;
+
+public class Ec2Wrapper
+{
+    private readonly IAmazonEc2 _client;
+    private readonly ILogger<Ec2Wrapper> _logger;
+
+    public Ec2Wrapper(IAmazonEc2 client, ILogger<Ec2Wrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/002-vpc-gs/dotnet/GettingStartedScenario.cs
+++ b/tuts/002-vpc-gs/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+
+var client = new AmazonEc2Client();
+Console.WriteLine("Running Ec2 getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/003-s3-gettingstarted/dotnet/003-s3-gettingstarted.csproj
+++ b/tuts/003-s3-gettingstarted/dotnet/003-s3-gettingstarted.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.S3" Version="3.*" /></ItemGroup></Project>

--- a/tuts/003-s3-gettingstarted/dotnet/GettingStartedScenario.cs
+++ b/tuts/003-s3-gettingstarted/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.S3;
+
+var client = new AmazonS3Client();
+Console.WriteLine("Running S3 getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/003-s3-gettingstarted/dotnet/S3Wrapper.cs
+++ b/tuts/003-s3-gettingstarted/dotnet/S3Wrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.S3;
+using Microsoft.Extensions.Logging;
+
+public class S3Wrapper
+{
+    private readonly IAmazonS3 _client;
+    private readonly ILogger<S3Wrapper> _logger;
+
+    public S3Wrapper(IAmazonS3 client, ILogger<S3Wrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/004-cloudmap-custom-attributes/dotnet/004-cloudmap-custom-attributes.csproj
+++ b/tuts/004-cloudmap-custom-attributes/dotnet/004-cloudmap-custom-attributes.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.CloudMap" Version="3.*" /></ItemGroup></Project>

--- a/tuts/004-cloudmap-custom-attributes/dotnet/CloudMapWrapper.cs
+++ b/tuts/004-cloudmap-custom-attributes/dotnet/CloudMapWrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CloudMap;
+using Microsoft.Extensions.Logging;
+
+public class CloudMapWrapper
+{
+    private readonly IAmazonCloudMap _client;
+    private readonly ILogger<CloudMapWrapper> _logger;
+
+    public CloudMapWrapper(IAmazonCloudMap client, ILogger<CloudMapWrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/004-cloudmap-custom-attributes/dotnet/GettingStartedScenario.cs
+++ b/tuts/004-cloudmap-custom-attributes/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CloudMap;
+
+var client = new AmazonCloudMapClient();
+Console.WriteLine("Running CloudMap getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/005-cloudfront-gettingstarted/dotnet/005-cloudfront-gettingstarted.csproj
+++ b/tuts/005-cloudfront-gettingstarted/dotnet/005-cloudfront-gettingstarted.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.CloudFront" Version="3.*" /></ItemGroup></Project>

--- a/tuts/005-cloudfront-gettingstarted/dotnet/CloudFrontWrapper.cs
+++ b/tuts/005-cloudfront-gettingstarted/dotnet/CloudFrontWrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CloudFront;
+using Microsoft.Extensions.Logging;
+
+public class CloudFrontWrapper
+{
+    private readonly IAmazonCloudFront _client;
+    private readonly ILogger<CloudFrontWrapper> _logger;
+
+    public CloudFrontWrapper(IAmazonCloudFront client, ILogger<CloudFrontWrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/005-cloudfront-gettingstarted/dotnet/GettingStartedScenario.cs
+++ b/tuts/005-cloudfront-gettingstarted/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CloudFront;
+
+var client = new AmazonCloudFrontClient();
+Console.WriteLine("Running CloudFront getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/008-vpc-private-servers-gs/dotnet/008-vpc-private-servers-gs.csproj
+++ b/tuts/008-vpc-private-servers-gs/dotnet/008-vpc-private-servers-gs.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.Ec2" Version="3.*" /></ItemGroup></Project>

--- a/tuts/008-vpc-private-servers-gs/dotnet/Ec2Wrapper.cs
+++ b/tuts/008-vpc-private-servers-gs/dotnet/Ec2Wrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+using Microsoft.Extensions.Logging;
+
+public class Ec2Wrapper
+{
+    private readonly IAmazonEc2 _client;
+    private readonly ILogger<Ec2Wrapper> _logger;
+
+    public Ec2Wrapper(IAmazonEc2 client, ILogger<Ec2Wrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/008-vpc-private-servers-gs/dotnet/GettingStartedScenario.cs
+++ b/tuts/008-vpc-private-servers-gs/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+
+var client = new AmazonEc2Client();
+Console.WriteLine("Running Ec2 getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/009-vpc-ipam-gs/dotnet/009-vpc-ipam-gs.csproj
+++ b/tuts/009-vpc-ipam-gs/dotnet/009-vpc-ipam-gs.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.Ec2" Version="3.*" /></ItemGroup></Project>

--- a/tuts/009-vpc-ipam-gs/dotnet/Ec2Wrapper.cs
+++ b/tuts/009-vpc-ipam-gs/dotnet/Ec2Wrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+using Microsoft.Extensions.Logging;
+
+public class Ec2Wrapper
+{
+    private readonly IAmazonEc2 _client;
+    private readonly ILogger<Ec2Wrapper> _logger;
+
+    public Ec2Wrapper(IAmazonEc2 client, ILogger<Ec2Wrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/009-vpc-ipam-gs/dotnet/GettingStartedScenario.cs
+++ b/tuts/009-vpc-ipam-gs/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+
+var client = new AmazonEc2Client();
+Console.WriteLine("Running Ec2 getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/010-cloudmap-service-discovery/dotnet/010-cloudmap-service-discovery.csproj
+++ b/tuts/010-cloudmap-service-discovery/dotnet/010-cloudmap-service-discovery.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.CloudMap" Version="3.*" /></ItemGroup></Project>

--- a/tuts/010-cloudmap-service-discovery/dotnet/CloudMapWrapper.cs
+++ b/tuts/010-cloudmap-service-discovery/dotnet/CloudMapWrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CloudMap;
+using Microsoft.Extensions.Logging;
+
+public class CloudMapWrapper
+{
+    private readonly IAmazonCloudMap _client;
+    private readonly ILogger<CloudMapWrapper> _logger;
+
+    public CloudMapWrapper(IAmazonCloudMap client, ILogger<CloudMapWrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/010-cloudmap-service-discovery/dotnet/GettingStartedScenario.cs
+++ b/tuts/010-cloudmap-service-discovery/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.CloudMap;
+
+var client = new AmazonCloudMapClient();
+Console.WriteLine("Running CloudMap getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/011-getting-started-batch-fargate/dotnet/011-getting-started-batch-fargate.csproj
+++ b/tuts/011-getting-started-batch-fargate/dotnet/011-getting-started-batch-fargate.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.Batch" Version="3.*" /></ItemGroup></Project>

--- a/tuts/011-getting-started-batch-fargate/dotnet/BatchWrapper.cs
+++ b/tuts/011-getting-started-batch-fargate/dotnet/BatchWrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Batch;
+using Microsoft.Extensions.Logging;
+
+public class BatchWrapper
+{
+    private readonly IAmazonBatch _client;
+    private readonly ILogger<BatchWrapper> _logger;
+
+    public BatchWrapper(IAmazonBatch client, ILogger<BatchWrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/011-getting-started-batch-fargate/dotnet/GettingStartedScenario.cs
+++ b/tuts/011-getting-started-batch-fargate/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Batch;
+
+var client = new AmazonBatchClient();
+Console.WriteLine("Running Batch getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");

--- a/tuts/012-transitgateway-gettingstarted/dotnet/012-transitgateway-gettingstarted.csproj
+++ b/tuts/012-transitgateway-gettingstarted/dotnet/012-transitgateway-gettingstarted.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk"><PropertyGroup><OutputType>Exe</OutputType><TargetFramework>net8.0</TargetFramework></PropertyGroup>
+<ItemGroup><PackageReference Include="AWSSDK.Ec2" Version="3.*" /></ItemGroup></Project>

--- a/tuts/012-transitgateway-gettingstarted/dotnet/Ec2Wrapper.cs
+++ b/tuts/012-transitgateway-gettingstarted/dotnet/Ec2Wrapper.cs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+using Microsoft.Extensions.Logging;
+
+public class Ec2Wrapper
+{
+    private readonly IAmazonEc2 _client;
+    private readonly ILogger<Ec2Wrapper> _logger;
+
+    public Ec2Wrapper(IAmazonEc2 client, ILogger<Ec2Wrapper> logger)
+    {
+        _client = client;
+        _logger = logger;
+    }
+
+    // TODO: Add async wrapper methods matching CLI tutorial actions
+}

--- a/tuts/012-transitgateway-gettingstarted/dotnet/GettingStartedScenario.cs
+++ b/tuts/012-transitgateway-gettingstarted/dotnet/GettingStartedScenario.cs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+using Amazon.Ec2;
+
+var client = new AmazonEc2Client();
+Console.WriteLine("Running Ec2 getting started scenario...");
+// TODO: setup, interact, teardown
+Console.WriteLine("Scenario complete.");


### PR DESCRIPTION
SDK examples in dotnet for tutorials 001-012. Each tutorial gets a `dotnet/` directory with wrapper, scenario, and test scaffolds.