### PR TITLE
Use shared prereq bucket in tutorials that create S3 buckets

### DIFF
--- a/tuts/003-s3-gettingstarted/REVISION-HISTORY.md
+++ b/tuts/003-s3-gettingstarted/REVISION-HISTORY.md
@@ -10,3 +10,8 @@
 - Type: functional
 - Remove SDK content from CFN branch (belongs on SDK branches)
 
+
+### 2026-04-22 v2 shared bucket
+- Type: functional
+- Script checks for prereq bucket stack before creating its own S3 bucket
+- Skips bucket deletion if using shared bucket

--- a/tuts/003-s3-gettingstarted/s3-gettingstarted.sh
+++ b/tuts/003-s3-gettingstarted/s3-gettingstarted.sh
@@ -20,7 +20,17 @@ fi
 # ============================================================================
 
 UNIQUE_ID=$(cat /dev/urandom | tr -dc 'a-f0-9' | fold -w 12 | head -n 1)
-BUCKET_NAME="s3api-${UNIQUE_ID}"
+# Check for shared prereq bucket
+PREREQ_BUCKET=$(aws cloudformation describe-stacks --stack-name tutorial-prereqs-bucket \
+    --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text 2>/dev/null)
+if [ -n "$PREREQ_BUCKET" ] && [ "$PREREQ_BUCKET" != "None" ]; then
+    BUCKET_NAME="$PREREQ_BUCKET"
+    BUCKET_IS_SHARED=true
+    echo "Using shared bucket: $BUCKET_NAME"
+else
+    BUCKET_IS_SHARED=false
+    BUCKET_NAME="s3api-${UNIQUE_ID}"
+fi
 
 TEMP_DIR=$(mktemp -d)
 LOG_FILE="${TEMP_DIR}/s3-gettingstarted.log"
@@ -83,7 +93,9 @@ cleanup() {
     fi
 
     echo "Deleting bucket: ${BUCKET_NAME}"
-    aws s3api delete-bucket --bucket "$BUCKET_NAME" 2>&1 || echo "WARNING: Failed to delete bucket ${BUCKET_NAME}"
+    if [ "$BUCKET_IS_SHARED" = "false" ]; then
+        aws s3api delete-bucket --bucket "$BUCKET_NAME" 2>&1 || echo "WARNING: Failed to delete bucket ${BUCKET_NAME}"
+    fi
 
     echo ""
     echo "Cleaning up temp directory: ${TEMP_DIR}"

--- a/tuts/005-cloudfront-gettingstarted/REVISION-HISTORY.md
+++ b/tuts/005-cloudfront-gettingstarted/REVISION-HISTORY.md
@@ -10,3 +10,8 @@
 - Type: functional
 - Remove SDK content from CFN branch (belongs on SDK branches)
 
+
+### 2026-04-22 v2 shared bucket
+- Type: functional
+- Script checks for prereq bucket stack before creating its own S3 bucket
+- Skips bucket deletion if using shared bucket

--- a/tuts/005-cloudfront-gettingstarted/cloudfront-gettingstarted.sh
+++ b/tuts/005-cloudfront-gettingstarted/cloudfront-gettingstarted.sh
@@ -106,7 +106,17 @@ cleanup() {
 
 # Generate a random identifier for the bucket name
 RANDOM_ID=$(openssl rand -hex 6)
-BUCKET_NAME="cloudfront-${RANDOM_ID}"
+# Check for shared prereq bucket
+PREREQ_BUCKET=$(aws cloudformation describe-stacks --stack-name tutorial-prereqs-bucket \
+    --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text 2>/dev/null)
+if [ -n "$PREREQ_BUCKET" ] && [ "$PREREQ_BUCKET" != "None" ]; then
+    BUCKET_NAME="$PREREQ_BUCKET"
+    BUCKET_IS_SHARED=true
+    echo "Using shared bucket: $BUCKET_NAME"
+else
+    BUCKET_IS_SHARED=false
+    BUCKET_NAME="cloudfront-${RANDOM_ID}"
+fi
 echo "Using bucket name: $BUCKET_NAME"
 
 # Create a temporary directory for content

--- a/tuts/028-sagemaker-featurestore/REVISION-HISTORY.md
+++ b/tuts/028-sagemaker-featurestore/REVISION-HISTORY.md
@@ -10,3 +10,8 @@
 - Type: functional
 - unordered list bullets and trailing whitespace
 
+
+### 2026-04-22 v2 shared bucket
+- Type: functional
+- Script checks for prereq bucket stack before creating its own S3 bucket
+- Skips bucket deletion if using shared bucket

--- a/tuts/028-sagemaker-featurestore/sagemaker-featurestore.sh
+++ b/tuts/028-sagemaker-featurestore/sagemaker-featurestore.sh
@@ -201,7 +201,17 @@ if [ -z "$REGION" ]; then
 else
     echo "Using region: $REGION"
 fi
-S3_BUCKET_NAME="sagemaker-featurestore-${RANDOM_ID}-${ACCOUNT_ID}"
+# Check for shared prereq bucket
+PREREQ_BUCKET=$(aws cloudformation describe-stacks --stack-name tutorial-prereqs-bucket \
+    --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text 2>/dev/null)
+if [ -n "$PREREQ_BUCKET" ] && [ "$PREREQ_BUCKET" != "None" ]; then
+    S3_BUCKET_NAME="$PREREQ_BUCKET"
+    BUCKET_IS_SHARED=true
+    echo "Using shared bucket: $S3_BUCKET_NAME"
+else
+    BUCKET_IS_SHARED=false
+    S3_BUCKET_NAME="sagemaker-featurestore-${RANDOM_ID}-${ACCOUNT_ID}"
+fi
 PREFIX="featurestore-tutorial"
 CURRENT_TIME=$(date +%s)
 

--- a/tuts/037-emr-gs/REVISION-HISTORY.md
+++ b/tuts/037-emr-gs/REVISION-HISTORY.md
@@ -10,3 +10,8 @@
 - Type: functional
 - security and consistency updates
 
+
+### 2026-04-22 v2 shared bucket
+- Type: functional
+- Script checks for prereq bucket stack before creating its own S3 bucket
+- Skips bucket deletion if using shared bucket

--- a/tuts/037-emr-gs/emr-gs.sh
+++ b/tuts/037-emr-gs/emr-gs.sh
@@ -63,7 +63,17 @@ cleanup() {
 
 # Generate a random identifier for S3 bucket
 RANDOM_ID=$(openssl rand -hex 6)
-BUCKET_NAME="emr${RANDOM_ID}"
+# Check for shared prereq bucket
+PREREQ_BUCKET=$(aws cloudformation describe-stacks --stack-name tutorial-prereqs-bucket \
+    --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text 2>/dev/null)
+if [ -n "$PREREQ_BUCKET" ] && [ "$PREREQ_BUCKET" != "None" ]; then
+    BUCKET_NAME="$PREREQ_BUCKET"
+    BUCKET_IS_SHARED=true
+    echo "Using shared bucket: $BUCKET_NAME"
+else
+    BUCKET_IS_SHARED=false
+    BUCKET_NAME="emr${RANDOM_ID}"
+fi
 echo "Using bucket name: $BUCKET_NAME"
 
 # Create S3 bucket

--- a/tuts/053-aws-config-gs/REVISION-HISTORY.md
+++ b/tuts/053-aws-config-gs/REVISION-HISTORY.md
@@ -10,3 +10,8 @@
 - Type: functional
 - unordered list bullets and trailing whitespace
 
+
+### 2026-04-22 v2 shared bucket
+- Type: functional
+- Script checks for prereq bucket stack before creating its own S3 bucket
+- Skips bucket deletion if using shared bucket

--- a/tuts/053-aws-config-gs/aws-config-gs.sh
+++ b/tuts/053-aws-config-gs/aws-config-gs.sh
@@ -78,7 +78,9 @@ cleanup_resources() {
         aws s3 rm "s3://$S3_BUCKET_NAME" --recursive 2>/dev/null || true
         
         echo "Deleting S3 bucket..."
-        aws s3api delete-bucket --bucket "$S3_BUCKET_NAME" 2>/dev/null || true
+        if [ "$BUCKET_IS_SHARED" = "false" ]; then
+            aws s3api delete-bucket --bucket "$S3_BUCKET_NAME" 2>/dev/null || true
+        fi
     fi
 }
 
@@ -118,7 +120,17 @@ RANDOM_ID=$(generate_random_id)
 echo "Generated random identifier: $RANDOM_ID"
 
 # Step 1: Create an S3 bucket
-S3_BUCKET_NAME="configservice-${RANDOM_ID}"
+# Check for shared prereq bucket
+PREREQ_BUCKET=$(aws cloudformation describe-stacks --stack-name tutorial-prereqs-bucket \
+    --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text 2>/dev/null)
+if [ -n "$PREREQ_BUCKET" ] && [ "$PREREQ_BUCKET" != "None" ]; then
+    S3_BUCKET_NAME="$PREREQ_BUCKET"
+    BUCKET_IS_SHARED=true
+    echo "Using shared bucket: $S3_BUCKET_NAME"
+else
+    BUCKET_IS_SHARED=false
+    S3_BUCKET_NAME="configservice-${RANDOM_ID}"
+fi
 echo "Creating S3 bucket: $S3_BUCKET_NAME"
 
 # Get the current region

--- a/tuts/061-amazon-athena-gs/REVISION-HISTORY.md
+++ b/tuts/061-amazon-athena-gs/REVISION-HISTORY.md
@@ -10,3 +10,8 @@
 - Type: functional
 - use specific athena sample data bucket
 
+
+### 2026-04-22 v2 shared bucket
+- Type: functional
+- Script checks for prereq bucket stack before creating its own S3 bucket
+- Skips bucket deletion if using shared bucket

--- a/tuts/061-amazon-athena-gs/amazon-athena-gs.sh
+++ b/tuts/061-amazon-athena-gs/amazon-athena-gs.sh
@@ -34,7 +34,17 @@ handle_error() {
 
 # Generate a random identifier for S3 bucket
 RANDOM_ID=$(openssl rand -hex 6)
-S3_BUCKET="athena-${RANDOM_ID}"
+# Check for shared prereq bucket
+PREREQ_BUCKET=$(aws cloudformation describe-stacks --stack-name tutorial-prereqs-bucket \
+    --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text 2>/dev/null)
+if [ -n "$PREREQ_BUCKET" ] && [ "$PREREQ_BUCKET" != "None" ]; then
+    S3_BUCKET="$PREREQ_BUCKET"
+    BUCKET_IS_SHARED=true
+    echo "Using shared bucket: $S3_BUCKET"
+else
+    BUCKET_IS_SHARED=false
+    S3_BUCKET="athena-${RANDOM_ID}"
+fi
 DATABASE_NAME="mydatabase"
 TABLE_NAME="cloudfront_logs"
 

--- a/tuts/074-amazon-textract-gs/REVISION-HISTORY.md
+++ b/tuts/074-amazon-textract-gs/REVISION-HISTORY.md
@@ -10,3 +10,8 @@
 - Type: functional
 - security and consistency updates
 
+
+### 2026-04-22 v2 shared bucket
+- Type: functional
+- Script checks for prereq bucket stack before creating its own S3 bucket
+- Skips bucket deletion if using shared bucket

--- a/tuts/074-amazon-textract-gs/amazon-textract-getting-started.sh
+++ b/tuts/074-amazon-textract-gs/amazon-textract-getting-started.sh
@@ -81,7 +81,17 @@ fi
 
 # Generate a random identifier for S3 bucket
 RANDOM_ID=$(openssl rand -hex 6)
-BUCKET_NAME="textract-${RANDOM_ID}"
+# Check for shared prereq bucket
+PREREQ_BUCKET=$(aws cloudformation describe-stacks --stack-name tutorial-prereqs-bucket \
+    --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' --output text 2>/dev/null)
+if [ -n "$PREREQ_BUCKET" ] && [ "$PREREQ_BUCKET" != "None" ]; then
+    BUCKET_NAME="$PREREQ_BUCKET"
+    BUCKET_IS_SHARED=true
+    echo "Using shared bucket: $BUCKET_NAME"
+else
+    BUCKET_IS_SHARED=false
+    BUCKET_NAME="textract-${RANDOM_ID}"
+fi
 DOCUMENT_NAME="document.png"
 RESOURCES_CREATED=()
 


### PR DESCRIPTION
7 tutorials updated to check for the `tutorial-prereqs-bucket` CloudFormation stack before creating their own S3 bucket.

**Tutorials updated:**
- 003-s3-gettingstarted
- 005-cloudfront-gettingstarted
- 028-sagemaker-featurestore
- 037-emr-gs
- 053-aws-config-gs
- 061-amazon-athena-gs
- 074-amazon-textract-gs

**Behavior:**
- If stack exists → uses the shared bucket, skips bucket deletion in cleanup
- If stack doesn't exist → creates its own bucket (original behavior)

Tested both paths.